### PR TITLE
Updated `wrapt` to version `1.14.1`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.14.0" %}
+{% set version = "1.14.1" %}
 
 package:
   name: wrapt
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/w/wrapt/wrapt-{{ version }}.tar.gz
-  sha256: 8323a43bd9c91f62bb7d4be74cc9ff10090e7ef820e27bfe8815c57e68261311
+  sha256: 380a85cf89e0e69b7cfbe2ea9f765f004ff419f34194018a6827ac0e3edfed4d
 
 build:
   number: 0


### PR DESCRIPTION
1. - [X] Check the upstream
    https://github.com/GrahamDumpleton/wrapt/tree/1.14.0


2. - [X] Check the pinnings
    setuptools--
    https://github.com/GrahamDumpleton/wrapt/blob/77634fa8a3e092b2e876f4ffec8849a0fe5a33fb/setup.cfg#L43
    python--
    https://github.com/GrahamDumpleton/wrapt/blob/77634fa8a3e092b2e876f4ffec8849a0fe5a33fb/setup.cfg#L37


3. - [X] Check the changelogs
    https://github.com/GrahamDumpleton/wrapt/blob/1.14.0/docs/changes.rst
    The changes mentioned are bug fixes and new features

4. - [X] Additional research
    https://github.com/conda-forge/wrapt-feedstock/issues

    No open issues mentioned in the change log at the time of the review.

5. - [X] Verify the `dev_url`
    https://github.com/GrahamDumpleton/wrapt

6. - [X] Verify the `doc_url`
    https://wrapt.readthedocs.io/en/latest/

7. - [X] License is `spdx` compliant
8. - [X] License family is present
9. - [X] Verify that the build number is correct
10. - [X] Verify if the package needs `setuptools`
11. - [X] Verify if the package needs `wheel`
12. - [X] `pip` in the test section
13. - [X] Verify the test section
14. - [X] Verify if the package is architecture specific or Noarch

 
Based on the research findings and the results we can conclude that it is safe to update `wrapt` to version `1.14.0`
