### PR TITLE
Update recipe for py313_codesign

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 380a85cf89e0e69b7cfbe2ea9f765f004ff419f34194018a6827ac0e3edfed4d
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<36]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.14.1" %}
+{% set version = "1.17.0" %}
 
 package:
   name: wrapt
@@ -6,12 +6,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/w/wrapt/wrapt-{{ version }}.tar.gz
-  sha256: 380a85cf89e0e69b7cfbe2ea9f765f004ff419f34194018a6827ac0e3edfed4d
+  sha256: 16187aa2317c731170a88ef35e8937ae0f533c402872c1ee5e6d079fcf320801
 
 build:
-  number: 1
+  number: 0
   skip: true  # [py<36]
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
   build:
@@ -42,8 +42,7 @@ about:
     The aim of the wrapt module is to provide a transparent object proxy for
     Python, which can be used as the basis for the construction of function
     wrappers and decorator functions.
-  doc_url: https://wrapt.readthedocs.io/en/latest/
-  doc_source_url: https://github.com/GrahamDumpleton/wrapt/blob/master/docs/index.rst
+  doc_url: https://wrapt.readthedocs.io
   dev_url: https://github.com/GrahamDumpleton/wrapt
 
 extra:


### PR DESCRIPTION
Rebuild for codesigned win-64 py313 artifacts.

Update to 1.17.0
https://github.com/GrahamDumpleton/wrapt/tree/1.17.0